### PR TITLE
Include ftw.theming.

### DIFF
--- a/ftw/colorbox/browser/resources/colorbox.scss
+++ b/ftw/colorbox/browser/resources/colorbox.scss
@@ -1,0 +1,67 @@
+$cbox-button-background-color: #fff !default;
+$cbox-button-size: 40px !default;
+
+@include declare-variables(
+    cbox-button-background-color,
+    cbox-button-size);
+
+#cboxContent {
+  > button {
+    background-image: none;
+    width: $cbox-button-size;
+    height: $cbox-button-size;
+    text-indent: 0;
+    font-size: 0;
+    @extend .fa-icon;
+    &:before {
+      font-size: $cbox-button-size / 2;
+      margin-right: 0 !important;
+    }
+  }
+}
+
+#cboxLoadedContent {
+  margin-bottom: $cbox-button-size;
+}
+
+#cboxPrevious {
+  @extend .fa-chevron-left;
+  background-color: $cbox-button-background-color;
+}
+
+#cboxNext {
+  @extend .fa-chevron-right;
+  background-color: $cbox-button-background-color;
+}
+
+#cboxClose {
+  @extend .fa-times;
+  width: 50px;
+  text-indent: 0;
+  font-size: 0;
+  padding: 0;
+  position: absolute;
+  bottom: $cbox-button-size;
+  right: 0;
+  padding-bottom: 20px;
+}
+
+#cboxTitle {
+  position: absolute;
+  bottom: $cbox-button-size;
+  background-color: rgba(255, 255, 255, .8);
+  padding: 20px 65px 20px 95px;
+  color: #000;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+#cboxCurrent {
+  position: absolute;
+  bottom: $cbox-button-size;
+  width: 80px;
+  text-align: center;
+  color: #000;
+  padding-bottom: 20px;
+  letter-spacing: 4px;
+}

--- a/ftw/colorbox/configure.zcml
+++ b/ftw/colorbox/configure.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.colorbox">
 
     <includeDependencies package="." />
@@ -9,6 +10,7 @@
     <i18n:registerTranslations directory="locales" />
 
     <include package=".browser" />
+    <include file="resources.zcml" zcml:condition="installed ftw.theming" />
 
     <genericsetup:registerProfile
         name="default"

--- a/ftw/colorbox/resources.zcml
+++ b/ftw/colorbox/resources.zcml
@@ -1,0 +1,11 @@
+
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:theme="http://namespaces.zope.org/ftw.theming"
+    i18n_domain="ftw.colorbox">
+
+    <include package="ftw.theming" file="meta.zcml" />
+
+    <theme:scss file="browser/resources/colorbox.scss" />
+
+</configure>


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/425

Fix height for title container. Use font-awesome icons for buttons.

Example in bern.web:

![bildschirmfoto 2015-08-20 um 11 31 09](https://cloud.githubusercontent.com/assets/1637820/9380255/52917bde-472f-11e5-8bfc-e1f393613aa9.png)
![bildschirmfoto 2015-08-20 um 11 31 42](https://cloud.githubusercontent.com/assets/1637820/9380256/52af6e5a-472f-11e5-98db-2312e2e4f424.png)
