### PR TITLE
The bottom border of the overlay is thicker than the others.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
+- Adjust border size of overlay for ftw.theming.
+  [Kevin Bieri]
+
 - Declare missing dependency to the "Plone" egg.
   [jone]
 

--- a/ftw/colorbox/browser/resources/colorbox.scss
+++ b/ftw/colorbox/browser/resources/colorbox.scss
@@ -21,7 +21,7 @@ $cbox-button-size: 40px !default;
 }
 
 #cboxLoadedContent {
-  margin-bottom: $cbox-button-size;
+  margin-bottom: 0;
 }
 
 #cboxPrevious {
@@ -41,27 +41,29 @@ $cbox-button-size: 40px !default;
   font-size: 0;
   padding: 0;
   position: absolute;
-  bottom: $cbox-button-size;
+  bottom: 0;
   right: 0;
   padding-bottom: 20px;
 }
 
 #cboxTitle {
   position: absolute;
-  bottom: $cbox-button-size;
+  bottom: 0;
   background-color: rgba(255, 255, 255, .8);
   padding: 20px 65px 20px 95px;
   color: #000;
   text-align: left;
   box-sizing: border-box;
+  font-weight: bold;
 }
 
 #cboxCurrent {
   position: absolute;
-  bottom: $cbox-button-size;
+  bottom: 0;
   width: 80px;
   text-align: center;
   color: #000;
   padding-bottom: 20px;
   letter-spacing: 4px;
+  font-weight: bold;
 }


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/801

Adjust all border to the same size.

<img width="750" alt="bildschirmfoto 2015-10-20 um 14 33 51" src="https://cloud.githubusercontent.com/assets/1637820/10607408/9f9b4678-7739-11e5-8b5d-d487191e9cee.png">