### PR TITLE
Improve caption of the colorbox.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The caption of the colorbox can now be provided by putting a "data-caption"
+  attribute on the link opening the colorbox.
+  [mbaechtold, mathias.leimgruber]
 
 
 1.2.3 (2015-12-23)

--- a/ftw/colorbox/browser/initalize_colorbox.py
+++ b/ftw/colorbox/browser/initalize_colorbox.py
@@ -11,9 +11,23 @@ class InitColorBoxView(BrowserView):
         settings = registry.forInterface(IColorboxSettings)
         return """
             var ftwColorboxInitialize = function() {
-                $('a.colorboxLink').colorbox({
-                    %s
-                });
+                var staticOptions = {
+                    'title': function(){
+                        var link = $(this);
+                        var title = link.attr('title');
+
+                        // Use the value from the attrib "data-caption" if there is one.
+                        var caption = link.data('caption');
+                        if (caption) {
+                            title = caption;
+                        }
+
+                        return title;
+                    }
+                }
+                var options = {%s}  // The options stored in the Plone registry.
+                $.extend(options, staticOptions)
+                $('a.colorboxLink').colorbox(options);
             }
             jQuery(function($) {
                 ftwColorboxInitialize();


### PR DESCRIPTION
The caption of the colorbox can now be provided by putting a "data-caption" attribute on the link opening the colorbox.