### PR TITLE
Fix rendering of empty colorbox title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix rendering of empty colorbox title.
+  [Kevin Bieri]
 
 
 1.2.4 (2017-01-23)

--- a/ftw/colorbox/browser/resources/colorbox.scss
+++ b/ftw/colorbox/browser/resources/colorbox.scss
@@ -55,6 +55,12 @@ $cbox-button-size: 40px !default;
   text-align: left;
   box-sizing: border-box;
   font-weight: bold;
+
+  // The colorbox title displays a white rectangle without any text
+  // So do not render the title when the element is empty
+  &:empty {
+    display: none !important;
+  }
 }
 
 #cboxCurrent {


### PR DESCRIPTION
Closes https://github.com/4teamwork/bumblebee.file/issues/33

Because the colorbox title displays a white rectangle without any text
do not render the title anymore.

![8b536158-ccee-11e6-958d-11b7adf35951](https://cloud.githubusercontent.com/assets/1637820/22597793/5dd137c2-ea31-11e6-9123-83f39e708785.png)

