### PR TITLE
Add plone5 compatibility

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 [instance]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Add plone 5 default profile. [mathias.leimgruber]
+
 - Fix rendering of empty colorbox title.
   [Kevin Bieri]
 

--- a/ftw/colorbox/browser/resources/colorbox.css
+++ b/ftw/colorbox/browser/resources/colorbox.css
@@ -20,14 +20,14 @@
 */
 #cboxOverlay{background:#fff;}
 #colorbox{}
-    #cboxTopLeft{width:25px; height:25px; background:url(++resource++ftw.colorbox.resources/border1.png) no-repeat 0 0;}
-    #cboxTopCenter{height:25px; background:url(++resource++ftw.colorbox.resources/border1.png) repeat-x 0 -50px;}
-    #cboxTopRight{width:25px; height:25px; background:url(++resource++ftw.colorbox.resources/border1.png) no-repeat -25px 0;}
-    #cboxBottomLeft{width:25px; height:25px; background:url(++resource++ftw.colorbox.resources/border1.png) no-repeat 0 -25px;}
-    #cboxBottomCenter{height:25px; background:url(++resource++ftw.colorbox.resources/border1.png) repeat-x 0 -75px;}
-    #cboxBottomRight{width:25px; height:25px; background:url(++resource++ftw.colorbox.resources/border1.png) no-repeat -25px -25px;}
-    #cboxMiddleLeft{width:25px; background:url(++resource++ftw.colorbox.resources/border2.png) repeat-y 0 0;}
-    #cboxMiddleRight{width:25px; background:url(++resource++ftw.colorbox.resources/border2.png) repeat-y -25px 0;}
+    #cboxTopLeft{width:25px; height:25px; background:url('++resource++ftw.colorbox.resources/border1.png') no-repeat 0 0;}
+    #cboxTopCenter{height:25px; background:url('++resource++ftw.colorbox.resources/border1.png') repeat-x 0 -50px;}
+    #cboxTopRight{width:25px; height:25px; background:url('++resource++ftw.colorbox.resources/border1.png') no-repeat -25px 0;}
+    #cboxBottomLeft{width:25px; height:25px; background:url('++resource++ftw.colorbox.resources/border1.png') no-repeat 0 -25px;}
+    #cboxBottomCenter{height:25px; background:url('++resource++ftw.colorbox.resources/border1.png') repeat-x 0 -75px;}
+    #cboxBottomRight{width:25px; height:25px; background:url('++resource++ftw.colorbox.resources/border1.png') no-repeat -25px -25px;}
+    #cboxMiddleLeft{width:25px; background:url('++resource++ftw.colorbox.resources/border2.png') repeat-y 0 0;}
+    #cboxMiddleRight{width:25px; background:url('++resource++ftw.colorbox.resources/border2.png') repeat-y -25px 0;}
     #cboxContent{background:#fff; overflow:hidden;}
         .cboxIframe{background:#fff;}
         #cboxError{padding:50px; border:1px solid #ccc;}
@@ -37,7 +37,7 @@
         #cboxSlideshow{position:absolute; bottom:0px; right:42px; color:#444;}
         #cboxPrevious{position:absolute; bottom:0px; left:0; color:#444;}
         #cboxNext{position:absolute; bottom:0px; left:63px; color:#444;}
-        #cboxLoadingOverlay{background:#fff url(++resource++ftw.colorbox.resources/loading.gif) no-repeat 5px 5px;}
+        #cboxLoadingOverlay{background:#fff url('++resource++ftw.colorbox.resources/loading.gif') no-repeat 5px 5px;}
         #cboxClose{position:absolute; bottom:0; right:0; display:block; color:#444;}
 
 /*
@@ -60,14 +60,14 @@
   The following provides PNG transparency support for IE6
   Feel free to remove this and the /ie6/ directory if you have dropped IE6 support.
 */
-.cboxIE6 #cboxTopLeft{background:url(++resource++ftw.colorbox.resources/borderTopLeft.png);}
-.cboxIE6 #cboxTopCenter{background:url(++resource++ftw.colorbox.resources/borderTopCenter.png);}
-.cboxIE6 #cboxTopRight{background:url(++resource++ftw.colorbox.resources/borderTopRight.png);}
-.cboxIE6 #cboxBottomLeft{background:url(++resource++ftw.colorbox.resources/borderBottomLeft.png);}
-.cboxIE6 #cboxBottomCenter{background:url(++resource++ftw.colorbox.resources/borderBottomCenter.png);}
-.cboxIE6 #cboxBottomRight{background:url(++resource++ftw.colorbox.resources/borderBottomRight.png);}
-.cboxIE6 #cboxMiddleLeft{background:url(++resource++ftw.colorbox.resources/borderMiddleLeft.png);}
-.cboxIE6 #cboxMiddleRight{background:url(++resource++ftw.colorbox.resources/borderMiddleRight.png);}
+.cboxIE6 #cboxTopLeft{background:url('++resource++ftw.colorbox.resources/borderTopLeft.png');}
+.cboxIE6 #cboxTopCenter{background:url('++resource++ftw.colorbox.resources/borderTopCenter.png');}
+.cboxIE6 #cboxTopRight{background:url('++resource++ftw.colorbox.resources/borderTopRight.png');}
+.cboxIE6 #cboxBottomLeft{background:url('++resource++ftw.colorbox.resources/borderBottomLeft.png');}
+.cboxIE6 #cboxBottomCenter{background:url('++resource++ftw.colorbox.resources/borderBottomCenter.png');}
+.cboxIE6 #cboxBottomRight{background:url('++resource++ftw.colorbox.resources/borderBottomRight.png');}
+.cboxIE6 #cboxMiddleLeft{background:url('++resource++ftw.colorbox.resources/borderMiddleLeft.png');}
+.cboxIE6 #cboxMiddleRight{background:url('++resource++ftw.colorbox.resources/borderMiddleRight.png');}
 
 .cboxIE6 #cboxTopLeft,
 .cboxIE6 #cboxTopCenter,
@@ -83,7 +83,7 @@
 
 #colorbox {outline:0;}
 #cboxContent button{border:none;}
-#cboxPrevious, #cboxNext, #cboxClose, #cboxSlideshow{position:absolute; bottom:-3px; background:url(++resource++ftw.colorbox.resources/controls.png) no-repeat 0px 0px; width:23px; height:23px; text-indent:-9999px;}
+#cboxPrevious, #cboxNext, #cboxClose, #cboxSlideshow{position:absolute; bottom:-3px; background:url('++resource++ftw.colorbox.resources/controls.png') no-repeat 0px 0px; width:23px; height:23px; text-indent:-9999px;}
 #cboxPrevious, #cboxNext {top:50%;}
 #cboxPrevious{left:0px; background-position: -51px -25px;}
 #cboxPrevious:hover{background-position:-51px 0px;}

--- a/ftw/colorbox/configure.zcml
+++ b/ftw/colorbox/configure.zcml
@@ -13,9 +13,19 @@
     <include file="resources.zcml" zcml:condition="installed ftw.theming" />
 
     <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
         name="default"
         title="ftw.colorbox"
         directory="profiles/default"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="default"
+        title="ftw.colorbox"
+        directory="profiles/default_plone5"
         description=""
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />

--- a/ftw/colorbox/profiles/default_plone5/cssregistry.xml
+++ b/ftw/colorbox/profiles/default_plone5/cssregistry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+    <stylesheet id="++resource++ftw.colorbox.resources/colorbox.css"
+                enabled="True" />
+</object>

--- a/ftw/colorbox/profiles/default_plone5/jsregistry.xml
+++ b/ftw/colorbox/profiles/default_plone5/jsregistry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+    <javascript id="++resource++ftw.colorbox.resources/jquery.colorbox-min.js"
+                enabled="True" />
+    <javascript cacheable="True" compression="safe" cookable="True"
+               enabled="True" expression=""
+               id="init-colorbox.js"
+               inline="False"
+               />
+</object>

--- a/ftw/colorbox/profiles/default_plone5/metadata.xml
+++ b/ftw/colorbox/profiles/default_plone5/metadata.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<metadata>
+</metadata>

--- a/ftw/colorbox/profiles/default_plone5/registry.xml
+++ b/ftw/colorbox/profiles/default_plone5/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry>
+  <records interface="ftw.colorbox.interfaces.IColorboxSettings" />
+
+  <records interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema"
+           prefix="plone">
+    <value key="allowed_sizes" purge="false">
+      <element>colorbox 2000:2000</element>
+    </value>
+  </records>
+
+</registry>

--- a/ftw/colorbox/profiles/default_plone5/types/Folder.xml
+++ b/ftw/colorbox/profiles/default_plone5/types/Folder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Folder"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="view_methods" purge="False">
+  <element value="colorbox_view"/>
+ </property>
+</object>

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = ftw.colorbox
+


### PR DESCRIPTION
- Add a separate profile for plone 5. Because of the image scale.
- Wrap single quotes around url() expressions in css. This fixes a SASSCompileError.