### PR TITLE
Fix colorbox overlay spacing and mobile styling

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Remove empty space when no counter is displayed and improve mobile styling.
+  [raphael-s]
+
 - Add plone 5 default profile. [mathias.leimgruber]
 
 - Fix rendering of empty colorbox title.

--- a/ftw/colorbox/browser/resources/colorbox.js
+++ b/ftw/colorbox/browser/resources/colorbox.js
@@ -1,0 +1,9 @@
+$(document).on('cbox_complete', function(){
+    var cboxTitle = $('#cboxTitle');
+
+    if ($('#cboxCurrent').is(':visible')) {
+        cboxTitle.css({'padding-left': '95px'});
+    } else {
+        cboxTitle.css({'padding-left': '20px'});
+    }
+});

--- a/ftw/colorbox/browser/resources/colorbox.scss
+++ b/ftw/colorbox/browser/resources/colorbox.scss
@@ -73,3 +73,24 @@ $cbox-button-size: 40px !default;
   letter-spacing: 4px;
   font-weight: bold;
 }
+
+/* Style mobile colorbox */
+#cboxWrapper {
+  #cboxTitle, #cboxCurrent {
+    font-size: 15px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    @include screen-small() {
+      font-size: 20px;
+      padding-top: 20px;
+      padding-bottom: 20px;
+    }
+  }
+
+  #cboxClose {
+    padding-bottom: 10px;
+    @include screen-small() {
+      padding-bottom: 20px;
+    }
+  }
+}

--- a/ftw/colorbox/profiles/default/jsregistry.xml
+++ b/ftw/colorbox/profiles/default/jsregistry.xml
@@ -7,4 +7,6 @@
                id="init-colorbox.js"
                inline="False"
                />
+    <javascript enabled="True" id="++resource++ftw.colorbox.resources/colorbox.js"
+        insert-after="init-colorbox.js" />
 </object>

--- a/ftw/colorbox/profiles/default_plone5/jsregistry.xml
+++ b/ftw/colorbox/profiles/default_plone5/jsregistry.xml
@@ -7,4 +7,6 @@
                id="init-colorbox.js"
                inline="False"
                />
+    <javascript enabled="True" id="++resource++ftw.colorbox.resources/colorbox.js"
+                insert-after="init-colorbox.js" />
 </object>

--- a/ftw/colorbox/upgrades/20180404095628_add_colorbox_js/jsregistry.xml
+++ b/ftw/colorbox/upgrades/20180404095628_add_colorbox_js/jsregistry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+    <javascript enabled="True" id="++resource++ftw.colorbox.resources/colorbox.js"
+        insert-after="init-colorbox.js" />
+</object>

--- a/ftw/colorbox/upgrades/20180404095628_add_colorbox_js/upgrade.py
+++ b/ftw/colorbox/upgrades/20180404095628_add_colorbox_js/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddColorboxJs(UpgradeStep):
+    """Add colorbox js.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Removes spacing when colorbox is opened without a "counter" (e.g. Galleryblock).
Also reduces font size and white-bars size on mobile.