### PR TITLE
 Add option to exclude images by a javascript expression

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add option to exclude images by a javascript expression [Nachtalb]
 
 
 1.3.0 (2018-04-04)

--- a/ftw/colorbox/browser/initalize_colorbox.py
+++ b/ftw/colorbox/browser/initalize_colorbox.py
@@ -9,6 +9,7 @@ class InitColorBoxView(BrowserView):
     def __call__(self):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(IColorboxSettings)
+        exclude_expression = settings.colorbox_exclude
         return """
             var ftwColorboxInitialize = function() {
                 var staticOptions = {
@@ -27,9 +28,9 @@ class InitColorBoxView(BrowserView):
                 }
                 var options = {%s}  // The options stored in the Plone registry.
                 $.extend(options, staticOptions)
-                $('a.colorboxLink').colorbox(options);
+                $('a.colorboxLink').not(function(){%s}).colorbox(options);
             }
             jQuery(function($) {
                 ftwColorboxInitialize();
             });
-        """ % ','.join(settings.colorbox_config)
+        """ % (','.join(settings.colorbox_config), exclude_expression)

--- a/ftw/colorbox/interfaces.py
+++ b/ftw/colorbox/interfaces.py
@@ -27,6 +27,20 @@ class IColorboxSettings(Interface):
             "'maxWidth': '100%'",
             "'maxHeight': '100%'"])
 
+    colorbox_exclude = schema.Text(
+        title=_(u'label_colorbox_exclude', default=u'Colorbox Exclude'),
+        description=_(u'help_colorbox_exlude',
+            default=u'Javascript that runs inside a jquery '
+                      '".not(function() { ... })" expression, where "this" is '
+                      'the a.colorbox element. The expression has to '
+                      'return either "true" for removing an item from the set '
+                      'or "false" to keep an item in the set. An example would '
+                      'bt to exlude certain classes: '
+                      '"return $(this).hasClass(\'slick-cloned\');"'),
+        default=u'return false;',
+        required=False,
+    )
+
     show_link = schema.Bool(
         title=_(u'label_showlink', default=u'Show link'),
         description=_(u'help_showlink',

--- a/ftw/colorbox/locales/de/LC_MESSAGES/ftw.colorbox.po
+++ b/ftw/colorbox/locales/de/LC_MESSAGES/ftw.colorbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2012-02-14 16:11+0000\n"
+"POT-Creation-Date: 2019-08-19 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,15 +10,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 msgid "download"
 msgstr "Herunterladen"
 
+#: ./ftw/colorbox/configure.zcml:22
+msgid "ftw.colorbox"
+msgstr ""
+
 #. Default: "The number of thumbnails shown on a page."
-#: ./ftw/colorbox/interfaces.py:47
+#: ./ftw/colorbox/interfaces.py:61
 msgid "help_batch_size"
 msgstr "Die Anzahl der anzuzeigenden Bilder auf einer Seite"
+
+#. Default: "Javascript that runs inside a jquery \".not(function() { ... })\" expression, where \"this\" is the a.colorbox element. The expression has to return either \"true\" for removing an item from the set or \"false\" to keep an item in the set. An example would bt to exlude certain classes: \"return $(this).hasClass('slick-cloned');\""
+#: ./ftw/colorbox/interfaces.py:32
+msgid "help_colorbox_exlude"
+msgstr ""
 
 #. Default: "One item per line. For example speed:500."
 #: ./ftw/colorbox/interfaces.py:21
@@ -31,19 +39,24 @@ msgid "help_imagesize"
 msgstr "Geben Sie die Bildgrösse an, die im Overlay angezeigt werden soll (z.B: large). Wenn keine Bildgrösse angegeben wird, wird das Bild in seiner Originalgrösse angezeigt."
 
 #. Default: "The number of images shown per row. If set to 0 all images are floated in the same row."
-#: ./ftw/colorbox/interfaces.py:39
+#: ./ftw/colorbox/interfaces.py:53
 msgid "help_row_size"
 msgstr "Die Anzahl Bilder die auf einer Zeile angezeigt werden soll."
 
 #. Default: "If enabled, a link to download the original image is displayed in the overlay."
-#: ./ftw/colorbox/interfaces.py:32
+#: ./ftw/colorbox/interfaces.py:46
 msgid "help_showlink"
 msgstr "Falls angewählt, wird ein Link zum Herunterladen des Originalbildes angezeigt."
 
 #. Default: "Batch Size"
-#: ./ftw/colorbox/interfaces.py:46
+#: ./ftw/colorbox/interfaces.py:60
 msgid "label_batch_size"
 msgstr "Batchgrösse"
+
+#. Default: "Colorbox Exclude"
+#: ./ftw/colorbox/interfaces.py:31
+msgid "label_colorbox_exclude"
+msgstr ""
 
 #. Default: "Colorbox config"
 #: ./ftw/colorbox/interfaces.py:20
@@ -56,13 +69,12 @@ msgid "label_imagesize"
 msgstr "Bildgrösse"
 
 #. Default: "Row Size"
-#: ./ftw/colorbox/interfaces.py:38
+#: ./ftw/colorbox/interfaces.py:52
 msgid "label_row_size"
 msgstr "Bilder pro Zeile"
 
 #. Default: "Show link"
-#: ./ftw/colorbox/interfaces.py:31
+#: ./ftw/colorbox/interfaces.py:45
 msgid "label_showlink"
 msgstr "Download-Link anzeigen?"
-
 

--- a/ftw/colorbox/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/colorbox/locales/de/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: plone\n"
 
 msgid "colorbox_view"
 msgstr "Colorbox Album"
+

--- a/ftw/colorbox/locales/en/LC_MESSAGES/ftw.colorbox.po
+++ b/ftw/colorbox/locales/en/LC_MESSAGES/ftw.colorbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2012-02-14 16:11+0000\n"
+"POT-Creation-Date: 2019-08-19 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,10 +14,19 @@ msgstr ""
 msgid "download"
 msgstr "download"
 
+#: ./ftw/colorbox/configure.zcml:22
+msgid "ftw.colorbox"
+msgstr ""
+
 #. Default: "The number of thumbnails shown on a page."
-#: ./ftw/colorbox/interfaces.py:47
+#: ./ftw/colorbox/interfaces.py:61
 msgid "help_batch_size"
 msgstr "The number of thumbnails shown on a page."
+
+#. Default: "Javascript that runs inside a jquery \".not(function() { ... })\" expression, where \"this\" is the a.colorbox element. The expression has to return either \"true\" for removing an item from the set or \"false\" to keep an item in the set. An example would bt to exlude certain classes: \"return $(this).hasClass('slick-cloned');\""
+#: ./ftw/colorbox/interfaces.py:32
+msgid "help_colorbox_exlude"
+msgstr ""
 
 #. Default: "One item per line. For example speed:500."
 #: ./ftw/colorbox/interfaces.py:21
@@ -30,19 +39,24 @@ msgid "help_imagesize"
 msgstr "Provide the name of an image size configured in the imaging control panel (e.g. large). If no size is given images will be displayed in original size."
 
 #. Default: "The number of images shown per row. If set to 0 all images are floated in the same row."
-#: ./ftw/colorbox/interfaces.py:39
+#: ./ftw/colorbox/interfaces.py:53
 msgid "help_row_size"
 msgstr "The number of images shown per row. If set to 0 all images are floated in the same row."
 
 #. Default: "If enabled, a link to download the original image is displayed in the overlay."
-#: ./ftw/colorbox/interfaces.py:32
+#: ./ftw/colorbox/interfaces.py:46
 msgid "help_showlink"
 msgstr "If enabled, a link to download the original image is displayed in the overlay."
 
 #. Default: "Batch Size"
-#: ./ftw/colorbox/interfaces.py:46
+#: ./ftw/colorbox/interfaces.py:60
 msgid "label_batch_size"
 msgstr "Batch Size"
+
+#. Default: "Colorbox Exclude"
+#: ./ftw/colorbox/interfaces.py:31
+msgid "label_colorbox_exclude"
+msgstr ""
 
 #. Default: "Colorbox config"
 #: ./ftw/colorbox/interfaces.py:20
@@ -55,11 +69,12 @@ msgid "label_imagesize"
 msgstr "Image size"
 
 #. Default: "Row Size"
-#: ./ftw/colorbox/interfaces.py:38
+#: ./ftw/colorbox/interfaces.py:52
 msgid "label_row_size"
 msgstr "Row Size"
 
 #. Default: "Show link"
-#: ./ftw/colorbox/interfaces.py:31
+#: ./ftw/colorbox/interfaces.py:45
 msgid "label_showlink"
 msgstr "Show link"
+

--- a/ftw/colorbox/locales/en/LC_MESSAGES/plone.po
+++ b/ftw/colorbox/locales/en/LC_MESSAGES/plone.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 msgid "colorbox_view"
 msgstr "Colorbox album"
+

--- a/ftw/colorbox/locales/fr/LC_MESSAGES/ftw.colorbox.po
+++ b/ftw/colorbox/locales/fr/LC_MESSAGES/ftw.colorbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-01-27 11:16+0000\n"
+"POT-Creation-Date: 2019-08-19 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,15 +10,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 msgid "download"
 msgstr "Télécharger"
 
+#: ./ftw/colorbox/configure.zcml:22
+msgid "ftw.colorbox"
+msgstr ""
+
 #. Default: "The number of thumbnails shown on a page."
-#: ./ftw/colorbox/interfaces.py:47
+#: ./ftw/colorbox/interfaces.py:61
 msgid "help_batch_size"
 msgstr "Le nombre d'images affichées sur une page"
+
+#. Default: "Javascript that runs inside a jquery \".not(function() { ... })\" expression, where \"this\" is the a.colorbox element. The expression has to return either \"true\" for removing an item from the set or \"false\" to keep an item in the set. An example would bt to exlude certain classes: \"return $(this).hasClass('slick-cloned');\""
+#: ./ftw/colorbox/interfaces.py:32
+msgid "help_colorbox_exlude"
+msgstr ""
 
 #. Default: "One item per line. For example speed:500."
 #: ./ftw/colorbox/interfaces.py:21
@@ -31,19 +39,24 @@ msgid "help_imagesize"
 msgstr "Mettre à disposition le nom / la taille de l'image configurée dans la base de l'imagerie (ex: large). Si aucune indication n'est donnée, l'image aura une taille définie."
 
 #. Default: "The number of images shown per row. If set to 0 all images are floated in the same row."
-#: ./ftw/colorbox/interfaces.py:39
+#: ./ftw/colorbox/interfaces.py:53
 msgid "help_row_size"
 msgstr "Le nombre d'images par lignes. Si défini sur 0, toutes les images seront sur la même ligne"
 
 #. Default: "If enabled, a link to download the original image is displayed in the overlay."
-#: ./ftw/colorbox/interfaces.py:32
+#: ./ftw/colorbox/interfaces.py:46
 msgid "help_showlink"
 msgstr "Si activé, un lien pour télécharger l'image originale est à disposition"
 
 #. Default: "Batch Size"
-#: ./ftw/colorbox/interfaces.py:46
+#: ./ftw/colorbox/interfaces.py:60
 msgid "label_batch_size"
 msgstr "Taille du Batch"
+
+#. Default: "Colorbox Exclude"
+#: ./ftw/colorbox/interfaces.py:31
+msgid "label_colorbox_exclude"
+msgstr ""
 
 #. Default: "Colorbox config"
 #: ./ftw/colorbox/interfaces.py:20
@@ -56,13 +69,12 @@ msgid "label_imagesize"
 msgstr "Taille d'image"
 
 #. Default: "Row Size"
-#: ./ftw/colorbox/interfaces.py:38
+#: ./ftw/colorbox/interfaces.py:52
 msgid "label_row_size"
 msgstr "Taille de la ligne"
 
 #. Default: "Show link"
-#: ./ftw/colorbox/interfaces.py:31
+#: ./ftw/colorbox/interfaces.py:45
 msgid "label_showlink"
 msgstr "Afficher le lien de téléchargement"
-
 

--- a/ftw/colorbox/locales/fr/LC_MESSAGES/plone.po
+++ b/ftw/colorbox/locales/fr/LC_MESSAGES/plone.po
@@ -13,3 +13,4 @@ msgstr ""
 
 msgid "colorbox_view"
 msgstr "Colorbox album"
+

--- a/ftw/colorbox/locales/ftw.colorbox.pot
+++ b/ftw/colorbox/locales/ftw.colorbox.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-01-27 11:16+0000\n"
+"POT-Creation-Date: 2019-08-19 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9,17 +9,23 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.colorbox\n"
 
 msgid "download"
 msgstr ""
 
+#: ./ftw/colorbox/configure.zcml:22
+msgid "ftw.colorbox"
+msgstr ""
+
 #. Default: "The number of thumbnails shown on a page."
-#: ./ftw/colorbox/interfaces.py:47
+#: ./ftw/colorbox/interfaces.py:61
 msgid "help_batch_size"
+msgstr ""
+
+#. Default: "Javascript that runs inside a jquery \".not(function() { ... })\" expression, where \"this\" is the a.colorbox element. The expression has to return either \"true\" for removing an item from the set or \"false\" to keep an item in the set. An example would bt to exlude certain classes: \"return $(this).hasClass('slick-cloned');\""
+#: ./ftw/colorbox/interfaces.py:32
+msgid "help_colorbox_exlude"
 msgstr ""
 
 #. Default: "One item per line. For example speed:500."
@@ -33,18 +39,23 @@ msgid "help_imagesize"
 msgstr ""
 
 #. Default: "The number of images shown per row. If set to 0 all images are floated in the same row."
-#: ./ftw/colorbox/interfaces.py:39
+#: ./ftw/colorbox/interfaces.py:53
 msgid "help_row_size"
 msgstr ""
 
 #. Default: "If enabled, a link to download the original image is displayed in the overlay."
-#: ./ftw/colorbox/interfaces.py:32
+#: ./ftw/colorbox/interfaces.py:46
 msgid "help_showlink"
 msgstr ""
 
 #. Default: "Batch Size"
-#: ./ftw/colorbox/interfaces.py:46
+#: ./ftw/colorbox/interfaces.py:60
 msgid "label_batch_size"
+msgstr ""
+
+#. Default: "Colorbox Exclude"
+#: ./ftw/colorbox/interfaces.py:31
+msgid "label_colorbox_exclude"
 msgstr ""
 
 #. Default: "Colorbox config"
@@ -58,12 +69,12 @@ msgid "label_imagesize"
 msgstr ""
 
 #. Default: "Row Size"
-#: ./ftw/colorbox/interfaces.py:38
+#: ./ftw/colorbox/interfaces.py:52
 msgid "label_row_size"
 msgstr ""
 
 #. Default: "Show link"
-#: ./ftw/colorbox/interfaces.py:31
+#: ./ftw/colorbox/interfaces.py:45
 msgid "label_showlink"
 msgstr ""
 

--- a/ftw/colorbox/upgrades/20190819121717_add_exclude_settings/registry.xml
+++ b/ftw/colorbox/upgrades/20190819121717_add_exclude_settings/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+    <records interface="ftw.colorbox.interfaces.IColorboxSettings" />
+</registry>

--- a/ftw/colorbox/upgrades/20190819121717_add_exclude_settings/upgrade.py
+++ b/ftw/colorbox/upgrades/20190819121717_add_exclude_settings/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddExcludeSettings(UpgradeStep):
+    """Add exclude settings.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Javascript that runs inside a jquery ".not(function() { ... })"
expression, where "this" is the a.colorbox element. The expression has
to return either "true" for removing an item from the set or "false" to
keep an item in the set. An example would bt to exlude certain classes:
"return $(this).hasClass('slick-cloned');"