### PR TITLE
Fix tests after ftw.testing release.

### DIFF
--- a/ftw/colorbox/tests/__init__.py
+++ b/ftw/colorbox/tests/__init__.py
@@ -1,7 +1,7 @@
 from ftw.colorbox.testing import FTW_COLORBOX_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 


### PR DESCRIPTION
Use unittest instead of unittest2 (dependency was not declared).