### PR TITLE
Fix bug when ftw.colorbox is not installed but in the path.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug when ftw.colorbox is not installed but in the path. [jone]
 
 
 1.5.0 (2019-12-18)

--- a/ftw/colorbox/browser/configure.zcml
+++ b/ftw/colorbox/browser/configure.zcml
@@ -24,7 +24,9 @@
   <adapter
       zcml:condition="have plone-5"
       factory=".initalize_colorbox.SettingsInjector"
-      for="* * *"
+      for="*
+           ftw.colorbox.interfaces.IColorboxLayer
+           *"
       name="colorbox_settings"
       provides="Products.CMFPlone.interfaces.IPatternsSettings"
   />

--- a/ftw/colorbox/interfaces.py
+++ b/ftw/colorbox/interfaces.py
@@ -3,6 +3,11 @@ from zope import schema
 from zope.interface import Interface
 
 
+class IColorboxLayer(Interface):
+    """Request layer for ftw.colorbox
+    """
+
+
 class IColorboxSettings(Interface):
     """Interface for registry entries.
     """

--- a/ftw/colorbox/profiles/default/browserlayer.xml
+++ b/ftw/colorbox/profiles/default/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+  <layer name="ftw.colorbox"
+         interface="ftw.colorbox.interfaces.IColorboxLayer" />
+
+</layers>

--- a/ftw/colorbox/profiles/default_plone5/browserlayer.xml
+++ b/ftw/colorbox/profiles/default_plone5/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+  <layer name="ftw.colorbox"
+         interface="ftw.colorbox.interfaces.IColorboxLayer" />
+
+</layers>

--- a/ftw/colorbox/profiles/uninstall/browserlayer.xml
+++ b/ftw/colorbox/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+
+  <layer name="ftw.colorbox" remove="True" />
+
+</layers>

--- a/ftw/colorbox/profiles/uninstall_plone5/browserlayer.xml
+++ b/ftw/colorbox/profiles/uninstall_plone5/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+
+  <layer name="ftw.colorbox" remove="True" />
+
+</layers>

--- a/ftw/colorbox/upgrades/20191218104259_add_browser_layer/browserlayer.xml
+++ b/ftw/colorbox/upgrades/20191218104259_add_browser_layer/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+
+  <layer name="ftw.colorbox"
+         interface="ftw.colorbox.interfaces.IColorboxLayer" />
+
+</layers>

--- a/ftw/colorbox/upgrades/20191218104259_add_browser_layer/upgrade.py
+++ b/ftw/colorbox/upgrades/20191218104259_add_browser_layer/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddBrowserLayer(UpgradeStep):
+    """Add browser layer.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Fixes the broken `ftw.simplelayout` builds, closes https://github.com/4teamwork/izug.organisation/issues/1713

The problem is thatt the pattern settings adapter was used even when ftw.colorbox was not installed, causing exceptions when the not-installed registry settings was read.

The solution is to use a browser layer and only provide the adapter for this browser layer and thus when ftw.colorbox is installed.