### PR TITLE
Fix registry entry in plone 4 -> 5 upgradestep

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix registry entry in plone 4 -> 5 upgradestep [Nachtalb]
 
 
 1.6.3 (2020-05-10)

--- a/ftw/colorbox/upgrades/20191120220748_move_resources_from_legacy_bundle_to_its_own/registry.xml
+++ b/ftw/colorbox/upgrades/20191120220748_move_resources_from_legacy_bundle_to_its_own/registry.xml
@@ -24,16 +24,12 @@
 
     <records prefix="plone.bundles/ftw-colorbox-resources"
              interface="Products.CMFPlone.interfaces.IBundleRegistry">
-        <value key="resources">
-            <element>ftwcolorbox_lib</element>
-            <element>ftwcolorbox_init</element>
-            <element>ftwcolorbox_additional</element>
-        </value>
         <value key="enabled">True</value>
         <value key="depends">plone</value>
+        <value key="stub_js_modules">jquery</value>
         <value key="compile">False</value>
-        <value key="jscompilation">++plone++ftw.colorbox.resources/ftw-colorbox-compiled.js</value>
-        <value key="csscompilation">++plone++ftw.colorbox.resources/ftw-colorbox-compiled.css</value>
+        <value key="jscompilation">++resource++ftw.colorbox.resources/ftw-colorbox-compiled.js</value>
+        <value key="last_compilation">2019-12-17 15:25:00</value>
         <value key="merge_with">default</value>
     </records>
 

--- a/ftw/colorbox/upgrades/20191217222027_reconfigure_bundling_on_plone5/registry.xml
+++ b/ftw/colorbox/upgrades/20191217222027_reconfigure_bundling_on_plone5/registry.xml
@@ -18,11 +18,11 @@
              interface="Products.CMFPlone.interfaces.IBundleRegistry">
         <value key="resources" purge="true">
         </value>
+        <value key="enabled">True</value>
         <value key="depends">plone</value>
         <value key="stub_js_modules">jquery</value>
         <value key="compile">False</value>
         <value key="jscompilation">++resource++ftw.colorbox.resources/ftw-colorbox-compiled.js</value>
-        <value key="csscompilation">++resource++ftw.colorbox.resources/ftw-colorbox-compiled.css</value>
         <value key="last_compilation">2019-12-17 15:25:00</value>
         <value key="merge_with">default</value>
     </records>


### PR DESCRIPTION
The problem here was that the files resource files were changed and thus the old upgrade steps didn't work anymore. They have to be adjusted so that we can successfully upgrade to Plone 5 without errors.

The definition for the registry entry is copied from the main `default_plone5/registry.xml`. 